### PR TITLE
Just a small warning fixed due to a change made in RxSwift 

### DIFF
--- a/Pod/Classes/RxCocoa Categories/Observable + Operations.swift
+++ b/Pod/Classes/RxCocoa Categories/Observable + Operations.swift
@@ -79,7 +79,7 @@ extension ObservableType {
         nextValue = $0
         
         let flush = flushNext
-        timer(interval, scheduler).subscribeNext { _ in
+        let _ = timer(interval, scheduler).subscribeNext { _ in
           flush(true)
         }
       }


### PR DESCRIPTION
Just a small warning fixed due to a change made in RxSwift where subscribeNext has @warn_unused_result https://github.com/ReactiveX/RxSwift/commit/1b5f7f41d99bf77422b92818f61c5fe73eefb34b